### PR TITLE
chore(*): add maven pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>cds.healpix</groupId>
+    <artifactId>cds-healpix</artifactId>
+    <packaging>jar</packaging>
+    <name>CDS Healpix</name>
+    <version>0.30</version>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.release>11</maven.compiler.release>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>
+


### PR DESCRIPTION
Bonjour,

Un petit ajout au projet sous forme de fichier de configuration Maven (l'outil de build le plus utilisé pour les projets java), afin de pouvoir ouvrir, compiler et lancer les tests du projet dans les IDE sans modifications : Netbeans, IntelliJ, Eclipse, VSCode...



